### PR TITLE
Fix cookie store default

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -60,7 +60,7 @@ export default (config = {}) => {
     : name => authenticators.find(authenticator => authenticator.name === name)
 
   return ({ dispatch, getState }) => {
-    const { authenticated = {} } = storage.restore()
+    const { authenticated = {} } = storage.restore() || {}
     const { authenticator: authenticatorName, ...data } = authenticated
     const authenticator = findAuthenticator(authenticatorName)
 

--- a/src/storage/cookie.js
+++ b/src/storage/cookie.js
@@ -20,5 +20,5 @@ export default (
       expires: expires && secondsFromNow(expires)
     })
   },
-  restore: () => Cookie.getJSON(name)
+  restore: () => Cookie.getJSON(name) || {}
 })

--- a/test/storage/cookie.spec.js
+++ b/test/storage/cookie.spec.js
@@ -106,5 +106,13 @@ describe('cookie store', () => {
 
       expect(result).toEqual({ key: 'value' })
     })
+
+    it('returns empty object if cookie is yet initialized', () => {
+      const cookieStore = createCookieStore({ name: 'not-persisted' })
+
+      const result = cookieStore.restore()
+
+      expect(result).toEqual({})
+    })
   })
 })


### PR DESCRIPTION
Closes https://github.com/jerelmiller/redux-simple-auth/issues/15

Ensures cookie storage falls back to empty object on restore if nothing has been persisted. Also ensures the middleware will default to an empty object for any storage to avoid issues getting authenticated property on `undefined`.