### PR TITLE
Export action types

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,32 @@ const mapStateToProps = state => ({
 })
 ```
 
+## Action Types
+
+If you just plain need to hook into actions dispatched from `redux-simple-auth`,
+you may import the action types themselves for use within your own reducers.
+
+```javascript
+import { actionTypes } from 'redux-simple-auth'
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case actionTypes.AUTHENTICATE_FAILED:
+      // do something
+  }
+}
+```
+
+The following actions are available action types
+
+* `AUTHENTICATE`
+* `AUTHENTICATE_FAILED`
+* `AUTHENTICATE_SUCCEEDED`
+* `FETCH`
+* `INVALIDATE_SESSION`
+* `RESTORE`
+* `RESTORE_FAILED`
+
 ## TODO
 
 - [ ] Built-in authenticators for common scenarios

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import * as _actionTypes from './actionTypes'
+
 export { default as createAuthMiddleware } from './middleware'
 export { default as reducer } from './reducer'
 export { default as createAuthenticator } from './createAuthenticator'
@@ -12,3 +14,5 @@ export {
   getIsAuthenticated,
   getAuthenticator
 } from './selectors'
+
+export const actionTypes = _actionTypes


### PR DESCRIPTION
References https://github.com/jerelmiller/redux-simple-auth/issues/15

Export action types via the main module export.