### PR TITLE
Add restoration value

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,8 @@ const mapStateToProps = state => ({
 
 ### `getIsRestored(state)`
 
-(_boolean_) Returns whether the session state has been restored.
+(_boolean_) Returns whether the session state has been restored. Useful if you
+need to block rendering until the session state has been fully initialized.
 
 ```javascript
 import { getIsRestored } from 'redux-simple-auth'

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ const mapStateToProps = state => ({
 import { getIsRestored } from 'redux-simple-auth'
 
 const mapStateToProps = state => ({
-  authenticator: getIsRestored(state)
+  isRestored: getIsRestored(state)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,18 @@ const mapStateToProps = state => ({
 })
 ```
 
+### `getIsRestored(state)`
+
+(_boolean_) Returns whether the session state has been restored.
+
+```javascript
+import { getIsRestored } from 'redux-simple-auth'
+
+const mapStateToProps = state => ({
+  authenticator: getIsRestored(state)
+})
+```
+
 ## Action Types
 
 If you just plain need to hook into actions dispatched from `redux-simple-auth`,

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ export { default as storage } from './storage/default'
 export {
   getSessionData,
   getIsAuthenticated,
-  getAuthenticator
+  getAuthenticator,
+  getIsRestored
 } from './selectors'
 
 export const actionTypes = _actionTypes

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -62,3 +62,4 @@ export default reducer
 export const getData = state => state.data
 export const getIsAuthenticated = state => state.isAuthenticated
 export const getAuthenticator = state => state.authenticator
+export const getIsRestored = state => state.isRestored

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,6 +10,7 @@ import {
 const initialState = {
   authenticator: null,
   isAuthenticated: false,
+  isRestored: false,
   data: {}
 }
 
@@ -37,6 +38,7 @@ const reducer = (state = initialState, action) => {
         ...state,
         authenticator: null,
         isAuthenticated: false,
+        isRestored: true,
         data: {}
       }
     case RESTORE: {
@@ -46,7 +48,8 @@ const reducer = (state = initialState, action) => {
         ...state,
         authenticator,
         data,
-        isAuthenticated: true
+        isAuthenticated: true,
+        isRestored: true
       }
     }
     default:

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -7,3 +7,5 @@ export const getIsAuthenticated = state =>
 
 export const getAuthenticator = state =>
   fromSession.getAuthenticator(state.session)
+
+export const getIsRestored = state => fromSession.getIsRestored(state.session)

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -13,6 +13,7 @@ describe('session reducer', () => {
     const expected = {
       authenticator: null,
       isAuthenticated: false,
+      isRestored: false,
       data: {}
     }
     const state = reducer(undefined, {})
@@ -43,6 +44,7 @@ describe('session reducer', () => {
     const expected = {
       authenticator: null,
       isAuthenticated: false,
+      isRestored: true,
       data: {}
     }
 
@@ -69,7 +71,12 @@ describe('session reducer', () => {
 
   it('handles AUTHENTICATE_FAILED', () => {
     const currentState = { isAuthenticated: false, data: {} }
-    const expected = { authenticator: null, isAuthenticated: false, data: {} }
+    const expected = {
+      authenticator: null,
+      isAuthenticated: false,
+      isRestored: true,
+      data: {}
+    }
 
     const state = reducer(currentState, authenticateFailed())
 
@@ -81,6 +88,7 @@ describe('session reducer', () => {
     const expected = {
       authenticator: 'credentials',
       isAuthenticated: true,
+      isRestored: true,
       data: { token: '1234' }
     }
 
@@ -97,6 +105,7 @@ describe('session reducer', () => {
     const expected = {
       authenticator: null,
       isAuthenticated: false,
+      isRestored: true,
       data: {}
     }
 

--- a/test/selectors.spec.js
+++ b/test/selectors.spec.js
@@ -36,4 +36,16 @@ describe('selectors', () => {
 
     expect(result).toEqual('credentials')
   })
+
+  it('includes selector to get isRestored', () => {
+    const state = {
+      session: {
+        isRestored: false
+      }
+    }
+
+    const result = selectors.getIsRestored(state)
+
+    expect(result).toEqual(false)
+  })
 })


### PR DESCRIPTION
Set a value to determine if the session state has been restored. Useful when wanting to hold off rendering until session state has been initialized.