### PR TITLE
Return a rejected promise when authentication fails

### DIFF
--- a/packages/redux-simple-auth/src/middleware.js
+++ b/packages/redux-simple-auth/src/middleware.js
@@ -114,7 +114,7 @@ export default (config = {}) => {
             .authenticate(action.payload)
             .then(
               data => dispatch(authenticateSucceeded(authenticator.name, data)),
-              error => dispatch(authenticateFailed(error))
+              error => Promise.reject(dispatch(authenticateFailed(error)))
             )
         }
         case FETCH: {

--- a/packages/redux-simple-auth/test/middleware.spec.js
+++ b/packages/redux-simple-auth/test/middleware.spec.js
@@ -232,7 +232,9 @@ describe('auth middleware', () => {
         const data = { username: 'test', password: 'password' }
         const action = authenticate('test', data)
 
-        await store.dispatch(action)
+        try {
+          await store.dispatch(action)
+        } catch (e) {}
 
         expect(store.getActions()).toContainEqual(authenticateFailed())
       })

--- a/packages/redux-simple-auth/test/middleware.spec.js
+++ b/packages/redux-simple-auth/test/middleware.spec.js
@@ -280,7 +280,7 @@ describe('auth middleware', () => {
 
         expect(() => store.dispatch(action)).toThrow(
           'No session data to invalidate. Be sure you authenticate the ' +
-          'session before you try to invalidate it'
+            'session before you try to invalidate it'
         )
       })
     })
@@ -292,11 +292,11 @@ describe('auth middleware', () => {
         })
         const middleware = configureMiddleware(authenticator)
         const mockStore = configureStore([middleware])
-        const store = mockStore({ session: { } })
+        const store = mockStore({ session: {} })
         await expect(store.dispatch(invalidateSession())).rejects.toEqual(
           new Error(
             'No authenticated session. Be sure you authenticate the session ' +
-            'before you try to invalidate it'
+              'before you try to invalidate it'
           )
         )
 
@@ -316,7 +316,7 @@ describe('auth middleware', () => {
 
         expect(() => store.dispatch(action)).toThrow(
           'No session data to invalidate. Be sure you authenticate the ' +
-          'session before you try to invalidate it' 
+            'session before you try to invalidate it'
         )
       })
     })

--- a/packages/redux-simple-auth/test/middleware.spec.js
+++ b/packages/redux-simple-auth/test/middleware.spec.js
@@ -236,6 +236,18 @@ describe('auth middleware', () => {
 
         expect(store.getActions()).toContainEqual(authenticateFailed())
       })
+
+      it('returns rejected promise', async () => {
+        const middleware = configureMiddleware(failAuthenticator)
+        const mockStore = configureStore([middleware])
+        const store = mockStore({ session: { isAuthenticated: false } })
+        const data = { username: 'test', password: 'password' }
+        const action = authenticate('test', data)
+
+        const promise = store.dispatch(action)
+
+        await expect(promise).rejects.toEqual(authenticateFailed())
+      })
     })
   })
 


### PR DESCRIPTION
Returns a rejected promise when dispatching `authenticate` and authentication fails.