### PR TITLE
Allows for general fetch options to be applied as well as fetch headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,9 +647,13 @@ const authMiddleware = createAuthMiddleware({
 
 * `data` (_object_): The session data
 
-* `block` (_function_): A callback function responsible for defining any headers
-  needed for authorization. It accepts a header name for its first argument and
-  that header's value as its second argument.
+* `block` (_function_): A callback function responsible for applying either 
+headers or options to the browser `fetch` function. The callback expects three arguments:
+  * name: a string as the name of the header or option.
+  * value: a string as the value of the header or option.
+  * type (optional): either `header` or `option` (or none). `header` applies 
+name/value pair as a fetch header. `option` applies name/value pair as a 
+fetch option. When no argument supplied, defaults to `header`.
 
 ### Store Enhancer
 

--- a/packages/redux-simple-auth/src/middleware.js
+++ b/packages/redux-simple-auth/src/middleware.js
@@ -136,8 +136,12 @@ export default (config = {}) => {
           const { headers = {} } = options
 
           if (authorize) {
-            authorize(getSessionData(state), (name, value) => {
-              headers[name] = value
+            authorize(getSessionData(state), (name, value, type) => {
+              if (!type || type === 'header') {
+                headers[name] = value
+              } else if (type === 'option') {
+                options[name] = value
+              }
             })
           }
 

--- a/packages/redux-simple-auth/test/middleware.spec.js
+++ b/packages/redux-simple-auth/test/middleware.spec.js
@@ -425,6 +425,49 @@ describe('FETCH dispatched', () => {
     })
   })
 
+  it('sets headers defined in authorize function when header type supplied', () => {
+    fetch.mockResponse(JSON.stringify({ ok: true }))
+    const middleware = createAuthMiddleware({
+      storage,
+      authorize: (data, block) => {
+        block('Authorization', data.token, 'header')
+      },
+      authenticator: testAuthenticator
+    })
+    const store = createStore({
+      middleware,
+      initialState: sessionState({ data: { token: '1235' } })
+    })
+
+    store.dispatch(fetchAction('https://test.com'))
+
+    expect(fetch).toHaveBeenCalledWith('https://test.com', {
+      headers: { Authorization: '1235' }
+    })
+  })
+
+  it('sets options defined in authorize function when option type supplied', () => {
+    fetch.mockResponse(JSON.stringify({ ok: true }))
+    const middleware = createAuthMiddleware({
+      storage,
+      authorize: (data, block) => {
+        block('credentials', 'same-origin', 'option')
+      },
+      authenticator: testAuthenticator
+    })
+    const store = createStore({
+      middleware,
+      initialState: sessionState({ data: { authenticated: true } })
+    })
+
+    store.dispatch(fetchAction('https://test.com'))
+
+    expect(fetch).toHaveBeenCalledWith('https://test.com', {
+      headers: {},
+      credentials: 'same-origin'
+    })
+  })
+
   describe('when refresh option is set', () => {
     it('dispatches update session action', async () => {
       fetch.mockResponse(JSON.stringify({ ok: true }), {


### PR DESCRIPTION
- update `block` callback API to support optional `type` parameter which controls how the authorizer gets applied to fetch.
- unit test and read me update

Resolves: #66